### PR TITLE
feat: make Ajax request cacheable

### DIFF
--- a/js/AbTests.js
+++ b/js/AbTests.js
@@ -227,10 +227,7 @@
       return new Promise((resolve, reject) => {
         Drupal.ajax({
           url: `/ab-tests/render/${uuid}/${displayMode}`,
-          submit: {
-            uuid,
-            display_mode: displayMode
-          }
+          httpMethod: 'GET',
         }).execute()
           .then(resolve)
           .catch(reject);


### PR DESCRIPTION
This is the request that renders the entity with the view mode that the decider provides