### PR TITLE
fix: include missing attachments

### DIFF
--- a/src/Controller/AbTestsController.php
+++ b/src/Controller/AbTestsController.php
@@ -79,8 +79,12 @@ final class AbTestsController extends ControllerBase {
     $rendered = $this->renderer->executeInRenderContext($context, function () use ($build) {
       return $this->renderer->render($build, TRUE);
     });
+    // Add the assets, libraries, settings, and cache information bubbled up
+    // during rendering.
     while (!$context->isEmpty()) {
-      $response->addCacheableDependency($context->pop());
+      $metadata = $context->pop();
+      $response->addAttachments($metadata->getAttachments());
+      $response->addCacheableDependency($metadata);
     }
 
     // Create and add the replace command.


### PR DESCRIPTION
The previous improved some code during the Ajax rendering. However, it left out the attachments that bubble up during rendering.