### PR TITLE
feat: add configuration import/export ignore option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ Trackers manage the reporting of:
 - How users interact with each variant.
 - Custom events and metrics.
 
+## Configuration
+
+### Ignoring Configuration Export
+The module provides an option to ignore A/B test configurations during configuration export. This is useful when you want to:
+- Keep A/B test configurations out of version control
+- Have different A/B test settings per environment
+- Prevent A/B tests from being deployed/overritten across environments
+
+To enable this feature, navigate to /admin/config/search/ab-tests and check the box.
+
+When enabled, any third-party settings from the A/B Tests module will be excluded during configuration export and import.
+
 ## Creating a Custom Decider
 
 To create a custom decider, implement `\Drupal\ab_tests\Plugin\AbVariantDecider\AbVariantDeciderInterface`. The `ab_variant_decider_timeout` module provides a practical example:

--- a/ab_tests.links.menu.yml
+++ b/ab_tests.links.menu.yml
@@ -1,0 +1,6 @@
+ab_tests.settings:
+  title: 'A/B Tests'
+  description: 'Configure A/B Tests module settings.'
+  parent: system.admin_config_search
+  route_name: ab_tests.settings
+  weight: 0

--- a/ab_tests.module
+++ b/ab_tests.module
@@ -8,13 +8,11 @@ declare(strict_types=1);
  */
 
 use Drupal\ab_tests\Hook\AbTestsHooks;
-use Drupal\Core\Config\StorageInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Hook\Attribute\LegacyHook;
 use Drupal\Core\Routing\RouteMatchInterface;
-use Drupal\node\Entity\NodeType;
 
 /**
  * Implements hook_help().

--- a/ab_tests.module
+++ b/ab_tests.module
@@ -8,11 +8,13 @@ declare(strict_types=1);
  */
 
 use Drupal\ab_tests\Hook\AbTestsHooks;
+use Drupal\Core\Config\StorageInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Hook\Attribute\LegacyHook;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\node\Entity\NodeType;
 
 /**
  * Implements hook_help().

--- a/ab_tests.routing.yml
+++ b/ab_tests.routing.yml
@@ -5,3 +5,11 @@ ab_tests.render_variant:
     _controller: '\Drupal\ab_tests\Controller\AbTestsController::renderVariant'
   requirements:
     _permission: 'access content'
+
+ab_tests.settings:
+  path: '/admin/config/search/ab-tests'
+  defaults:
+    _form: '\Drupal\ab_tests\Form\AbTestsSettingsForm'
+    _title: 'A/B Tests Settings'
+  requirements:
+    _permission: 'administer site configuration'

--- a/config/install/ab_tests.settings.yml
+++ b/config/install/ab_tests.settings.yml
@@ -1,0 +1,1 @@
+ignore_config_export: false

--- a/config/schema/ab_tests.schema.yml
+++ b/config/schema/ab_tests.schema.yml
@@ -1,0 +1,7 @@
+ab_tests.settings:
+  type: config_object
+  label: 'A/B Tests settings'
+  mapping:
+    ignore_config_export:
+      type: boolean
+      label: 'Ignore A/B Tests configuration during configuration export'

--- a/src/Form/AbTestsSettingsForm.php
+++ b/src/Form/AbTestsSettingsForm.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ab_tests\Form;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Settings form for A/B Tests.
+ */
+final class AbTestsSettingsForm extends ConfigFormBase {
+
+  /**
+   * Constructs a new AbTestsSettingsForm.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory service.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler service.
+   */
+  public function __construct(
+    ConfigFactoryInterface $config_factory,
+    private readonly ModuleHandlerInterface $moduleHandler,
+  ) {
+    parent::__construct($config_factory);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): self {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('module_handler'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames(): array {
+    return ['ab_tests.settings'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId(): string {
+    return 'ab_tests_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state): array {
+    $config = $this->config('ab_tests.settings');
+    $config_filter_installed = $this->moduleHandler->moduleExists('config_filter');
+
+    // Default to FALSE if config_filter is not installed.
+    $default_value = $config_filter_installed ? ($config->get('ignore_config_export') ?? FALSE) : FALSE;
+
+    $form['ignore_config_export'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Ignore A/B Tests configuration during configuration export'),
+      '#description' => $this->t('When enabled, third-party settings for A/B Tests will not be included in the configuration export.'),
+      '#default_value' => $default_value,
+      '#disabled' => !$config_filter_installed,
+    ];
+
+    if (!$config_filter_installed) {
+      $config_filter_url = Url::fromUri('https://www.drupal.org/project/config_filter', [
+        'attributes' => ['target' => '_blank'],
+      ]);
+      $config_filter_link = Link::fromTextAndUrl('Config Filter', $config_filter_url)->toString();
+
+      $form['config_filter_notice'] = [
+        '#type' => 'markup',
+        '#markup' => '<div class="messages messages--warning">' . $this->t('The @config_filter module is required to ignore A/B Tests settings in the configuration export. Install the module to enable this feature.', [
+          '@config_filter' => $config_filter_link,
+        ]) . '</div>',
+        '#weight' => -10,
+      ];
+    }
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state): void {
+    // Only save the setting if config_filter is installed.
+    if ($this->moduleHandler->moduleExists('config_filter')) {
+      $this->config('ab_tests.settings')
+        ->set('ignore_config_export', $form_state->getValue('ignore_config_export'))
+        ->save();
+    }
+
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/src/Hook/AbTestsHooks.php
+++ b/src/Hook/AbTestsHooks.php
@@ -12,6 +12,8 @@ use Drupal\ab_tests\EntityHelper;
 use Drupal\Component\Plugin\Exception\PluginException;
 use Drupal\Component\Plugin\PluginInspectionInterface;
 use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\StorageInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
 use Drupal\Core\Entity\EntityFormInterface;
@@ -19,10 +21,12 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Form\SubformState;
 use Drupal\Core\Hook\Attribute\Hook;
+use Drupal\Core\Link;
 use Drupal\Core\Plugin\PluginFormInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Routing\RouteObjectInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Url;
 use Drupal\node\Entity\NodeType;
 use Drupal\node\NodeTypeInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -61,7 +65,7 @@ class AbTestsHooks {
     private readonly RequestStack $requestStack,
     private readonly AbVariantDeciderPluginManager $variantDeciderManager,
     private readonly RouteMatchInterface $routeMatch,
-    private readonly AbAnalyticsPluginManager $analyticsManager,
+    private readonly AbAnalyticsPluginManager $analyticsManager, private readonly ConfigFactoryInterface $config,
   ) {}
 
   /**
@@ -210,6 +214,19 @@ class AbTestsHooks {
     if (isset($form['additional_settings']) && $form['additional_settings']['#type'] === 'vertical_tabs') {
       $form['ab_tests']['#group'] = 'additional_settings';
     }
+
+    // Add a message about the export config setting if it's enabled.
+    $config = \Drupal::config('ab_tests.settings');
+    $settings_link = Link::createFromRoute($this->t('A/B Tests settings'), 'ab_tests.settings');
+    $message = $config->get('ignore_config_export')
+      ? $this->t('Note: A/B Tests configuration is currently set to be <strong>ignored</strong> during configuration export. This setting can be changed in the @settings_link.', ['@settings_link' => $settings_link->toString()])
+      : $this->t('Note: A/B Tests configuration will be <strong>exported</strong> during configuration export. This setting can be changed in the @settings_link.', ['@settings_link' => $settings_link->toString()]);
+    $form['ab_tests']['export_notice'] = [
+      '#type' => 'markup',
+      '#markup' => '<div class="messages messages--status">' . $message . '</div>',
+      '#weight' => -10,
+    ];
+
     $form['ab_tests']['is_active'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Enable A/B tests'),

--- a/src/Hook/AbTestsHooks.php
+++ b/src/Hook/AbTestsHooks.php
@@ -13,7 +13,6 @@ use Drupal\Component\Plugin\Exception\PluginException;
 use Drupal\Component\Plugin\PluginInspectionInterface;
 use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\Config\StorageInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
 use Drupal\Core\Entity\EntityFormInterface;
@@ -26,7 +25,6 @@ use Drupal\Core\Plugin\PluginFormInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Routing\RouteObjectInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Drupal\Core\Url;
 use Drupal\node\Entity\NodeType;
 use Drupal\node\NodeTypeInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -58,6 +56,8 @@ class AbTestsHooks {
    *   The route match.
    * @param \Drupal\ab_tests\AbAnalyticsPluginManager $analyticsManager
    *   The analytics manager.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory.
    */
   public function __construct(
     private readonly EntityHelper $entityHelper,
@@ -65,7 +65,8 @@ class AbTestsHooks {
     private readonly RequestStack $requestStack,
     private readonly AbVariantDeciderPluginManager $variantDeciderManager,
     private readonly RouteMatchInterface $routeMatch,
-    private readonly AbAnalyticsPluginManager $analyticsManager, private readonly ConfigFactoryInterface $config,
+    private readonly AbAnalyticsPluginManager $analyticsManager,
+    private readonly ConfigFactoryInterface $configFactory,
   ) {}
 
   /**
@@ -175,7 +176,8 @@ class AbTestsHooks {
    */
   #[Hook('hook_preprocess_node')]
   public function preprocessNode(&$variables): void {
-    $route_name = $this->requestStack->getCurrentRequest()->get(RouteObjectInterface::ROUTE_NAME);
+    $route_name = $this->requestStack->getCurrentRequest()
+      ->get(RouteObjectInterface::ROUTE_NAME);
     if ($route_name !== 'ab_tests.render_variant') {
       return;
     }
@@ -216,7 +218,7 @@ class AbTestsHooks {
     }
 
     // Add a message about the export config setting if it's enabled.
-    $config = \Drupal::config('ab_tests.settings');
+    $config = $this->configFactory->get('ab_tests.settings');
     $settings_link = Link::createFromRoute($this->t('A/B Tests settings'), 'ab_tests.settings');
     $message = $config->get('ignore_config_export')
       ? $this->t('Note: A/B Tests configuration is currently set to be <strong>ignored</strong> during configuration export. This setting can be changed in the @settings_link.', ['@settings_link' => $settings_link->toString()])

--- a/src/Plugin/ConfigFilter/AbTestsConfigFilter.php
+++ b/src/Plugin/ConfigFilter/AbTestsConfigFilter.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ab_tests\Plugin\ConfigFilter;
+
+use Drupal\config_filter\Plugin\ConfigFilterBase;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Filters out AB Tests settings during config export.
+ *
+ * @ConfigFilter(
+ *   id = "ab_tests_config_filter",
+ *   label = "AB Tests Config Filter",
+ *   weight = 0
+ * )
+ */
+class AbTestsConfigFilter extends ConfigFilterBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Constructs a new AbTestsConfigFilter.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ConfigFactoryInterface $config_factory) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function filterWrite($name, array $data) {
+    $config = $this->configFactory->get('ab_tests.settings');
+    if (!$config->get('ignore_config_export')) {
+      return $data;
+    }
+
+    // Only filter node type configuration.
+    if (!str_starts_with($name, 'node.type.')) {
+      return $data;
+    }
+    // Remove AB Tests third-party settings.
+    if (isset($data['third_party_settings']['ab_tests'])) {
+      unset($data['third_party_settings']['ab_tests']);
+
+      // If there are no more third-party settings, remove the array.
+      if (empty($data['third_party_settings'])) {
+        unset($data['third_party_settings']);
+      }
+    }
+    return $data;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function filterRead($name, $data) {
+    $config = $this->configFactory->get('ab_tests.settings');
+    if (!$config->get('ignore_config_export')) {
+      return $data;
+    }
+
+    // Only filter node type configuration.
+    if (!str_starts_with($name, 'node.type.')) {
+      return $data;
+    }
+    // Load the current configuration and copy the A/B Tests settings to it.
+    $config = $this->configFactory->get($name);
+    $ab_tests_settings = $config->get('third_party_settings.ab_tests');
+    if (!empty($ab_tests_settings)) {
+      $data['third_party_settings']['ab_tests'] = $ab_tests_settings;
+    }
+    return $data;
+  }
+
+}


### PR DESCRIPTION
- Introduced a settings form for the A/B Tests module at /admin/config/search/ab-tests.
- Added configuration option to ignore A/B Tests settings during configuration export.
- Updated routing and menu links for A/B Tests settings.
- Implemented schema for A/B Tests settings configuration.
- Added config filter to exclude A/B Tests settings from node type configuration during export.