### PR TITLE
Fix plugin selection form with empty settings array

### DIFF
--- a/src/Form/PluginSelectionFormTrait.php
+++ b/src/Form/PluginSelectionFormTrait.php
@@ -110,7 +110,10 @@ trait PluginSelectionFormTrait {
 
     $settings = $multiple_cardinality
       ? $settings
-      : array_combine($selected_plugin_ids, [$settings]);
+      : array_map(
+        static fn (string $selected_plugin_id) => $settings,
+        $selected_plugin_ids,
+      );
     // List all plugins with settings for selected ones.
     $plugin_settings = array_reduce(
       $selected_plugin_ids,


### PR DESCRIPTION
## Summary
- Fixed PHP warnings when plugin selection form has empty settings array
- Replaced `array_combine()` with `array_map()` to handle edge case where selected plugin IDs exist but settings array is empty
- Ensures proper initialization of plugin settings for single-cardinality forms

## Test plan
- [x] Test plugin selection form with empty initial settings
- [x] Verify no PHP warnings are generated during form processing
- [x] Confirm form functionality remains intact for normal use cases