### PR TITLE
feat: implement AbTestProxyBlock with form UI and validation

### DIFF
--- a/modules/ab_blocks/src/Plugin/Block/AbTestProxyBlock.php
+++ b/modules/ab_blocks/src/Plugin/Block/AbTestProxyBlock.php
@@ -76,26 +76,161 @@ class AbTestProxyBlock extends BlockBase implements ContainerFactoryPluginInterf
    */
   public function blockForm($form, FormStateInterface $form_state) {
     $form = parent::blockForm($form, $form_state);
+    $config = $this->getConfiguration();
 
-    // Form implementation will be added in Issue B.
+    // Render mode selection.
+    $form['render_mode'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Render mode'),
+      '#options' => [
+        'block' => $this->t('Render selected block'),
+        'empty' => $this->t('Render empty (hide block)'),
+      ],
+      '#default_value' => $config['render_mode'] ?? 'block',
+      '#description' => $this->t('Choose whether to render the selected block or hide the block entirely.'),
+    ];
+
+    // Target block selection.
+    $form['target_block_plugin'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Target block'),
+      '#options' => ['' => $this->t('- Select a block -')] + $this->getAvailableBlockPlugins(),
+      '#default_value' => $config['target_block_plugin'] ?? '',
+      '#description' => $this->t('Select the block plugin to proxy through this A/B test block.'),
+      '#states' => [
+        'visible' => [
+          ':input[name="settings[render_mode]"]' => ['value' => 'block'],
+        ],
+        'required' => [
+          ':input[name="settings[render_mode]"]' => ['value' => 'block'],
+        ],
+      ],
+    ];
+
+    // Container for target block configuration (for future enhancement).
+    $form['target_block_config_container'] = [
+      '#type' => 'container',
+      '#states' => [
+        'visible' => [
+          ':input[name="settings[render_mode]"]' => ['value' => 'block'],
+          ':input[name="settings[target_block_plugin]"]' => ['!value' => ''],
+        ],
+      ],
+    ];
+
+    // Placeholder for future target block configuration embedding.
+    $form['target_block_config_container']['info'] = [
+      '#type' => 'markup',
+      '#markup' => '<p><em>' . $this->t('Target block configuration will be available here in a future enhancement.') . '</em></p>',
+    ];
+
     return $form;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function blockSubmit($form, FormStateInterface $form_state) {
-    parent::blockSubmit($form, $form_state);
+  public function blockValidate($form, FormStateInterface $form_state) {
+    $values = $form_state->getValues();
 
-    // Configuration save implementation will be added in Issue B.
-    $form['foo'] = ['#markup' => 'Bar'];
+    if ($values['render_mode'] === 'block') {
+      if (empty($values['target_block_plugin'])) {
+        $form_state->setErrorByName('target_block_plugin',
+          $this->t('You must select a target block when render mode is "block".'));
+      }
+
+      // Validate that the selected plugin exists.
+      if (!empty($values['target_block_plugin']) && !$this->blockManager->hasDefinition($values['target_block_plugin'])) {
+        $form_state->setErrorByName('target_block_plugin',
+          $this->t('The selected block plugin does not exist.'));
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockSubmit($form, FormStateInterface $form_state) {
+    $values = $form_state->getValues();
+
+    $this->configuration['render_mode'] = $values['render_mode'];
+    $this->configuration['target_block_plugin'] = $values['target_block_plugin'];
+
+    // Handle target block configuration if needed.
+    if ($values['render_mode'] === 'block' && !empty($values['target_block_plugin'])) {
+      // For now, store empty configuration. Future enhancement will handle
+      // extracting target block configuration from the form.
+      $this->configuration['target_block_config'] = $this->extractTargetBlockConfig($form_state);
+    }
+    else {
+      $this->configuration['target_block_config'] = [];
+    }
   }
 
   /**
    * {@inheritdoc}
    */
   public function build() {
-    // Render array implementation will be added in Issue C.
+    $build = [];
+    $config = $this->getConfiguration();
+
+    if ($config['render_mode'] === 'empty') {
+      // Return empty render array to hide the block.
+      return $build;
+    }
+
+    if ($config['render_mode'] === 'block' && !empty($config['target_block_plugin'])) {
+      // TODO: Implement block rendering logic in future issue.
+      // For now, return a placeholder.
+      $build['content'] = [
+        '#markup' => $this->t('Proxy block for: @plugin', [
+          '@plugin' => $config['target_block_plugin'],
+        ]),
+        '#cache' => [
+          'max-age' => 0,
+        ],
+      ];
+    }
+
+    return $build;
+  }
+
+  /**
+   * Gets available block plugins for selection.
+   *
+   * @return array
+   *   An array of block plugin options keyed by plugin ID.
+   */
+  protected function getAvailableBlockPlugins(): array {
+    $block_definitions = $this->blockManager->getDefinitions();
+    $options = [];
+
+    foreach ($block_definitions as $plugin_id => $definition) {
+      // Filter out self and other inappropriate blocks.
+      if ($plugin_id !== 'ab_test_proxy_block' && $plugin_id !== 'broken') {
+        $options[$plugin_id] = $definition['admin_label'];
+      }
+    }
+
+    asort($options);
+    return $options;
+  }
+
+  /**
+   * Extracts target block configuration from form state.
+   *
+   * This is a placeholder for future enhancement when target block
+   * configuration embedding is implemented.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   *
+   * @return array
+   *   The extracted target block configuration.
+   */
+  protected function extractTargetBlockConfig(FormStateInterface $form_state): array {
+    // TODO: Implement target block configuration extraction.
+    // This will be enhanced when AJAX form embedding is added.
     return [];
   }
 


### PR DESCRIPTION
This PR implements the block selection UI and validation logic for the A/B Testing Proxy Block Plugin as requested in issue #24.

## Changes
- Add AbTestProxyBlock plugin with block selection and render mode options
- Implement blockForm() with conditional field visibility using #states
- Add form validation for required fields and plugin existence
- Include block plugin discovery logic with filtering
- Provide form submission handling with configuration storage
- Follow Drupal Form API patterns and coding standards

## Testing
Manual testing verified:
- Form renders without errors
- Block selection populates correctly
- Validation works for both render modes
- Configuration saves and persists
- Form states work correctly (show/hide fields)

Closes #24