### PR TITLE
fix: avoid premature block rendering

### DIFF
--- a/js/BaseDecisionHandler.js
+++ b/js/BaseDecisionHandler.js
@@ -182,7 +182,7 @@ class BaseDecisionHandler {
    * @return {Promise}
    *   Resolves when the variant is loaded.
    *
-   * @private
+   * @protected
    */
   async _loadVariant(element, decision) {
     return new Promise(resolve => {
@@ -206,7 +206,7 @@ class BaseDecisionHandler {
    * @param {Decision} decision
    *   The decision.
    *
-   * @private
+   * @protected
    */
   _handleError(error, element, decision) {
     this.error = true;

--- a/modules/ab_blocks/css/ab_blocks.css
+++ b/modules/ab_blocks/css/ab_blocks.css
@@ -1,6 +1,6 @@
 .ab-test-hidden .block--original {
-  display: none;
+  visibility: hidden;
 }
 .ab-test-loading {
-  display: none;
+  visibility: hidden;
 }

--- a/modules/ab_blocks/js/BlockDecisionHandler.js
+++ b/modules/ab_blocks/js/BlockDecisionHandler.js
@@ -5,7 +5,14 @@ class BlockDecisionHandler extends BaseDecisionHandler {
   async handleDecision(element, decision) {
     // Pre-enhance block metadata to avoid a nasty race condition.
     this._enhanceBlockMetadata(element, decision);
-    return super.handleDecision(element, decision);
+    try {
+      await this._loadVariant(element, decision);
+    } catch (error) {
+      this._handleError(error, element, decision);
+    }
+
+    // Dispatch decision event.
+    this._dispatchCustomEvent(element, decision);
   }
 
   /**
@@ -241,110 +248,5 @@ class BlockDecisionHandler extends BaseDecisionHandler {
   _bytesToBase64(bytes) {
     const binString = Array.from(bytes, x => String.fromCodePoint(x)).join('');
     return btoa(binString);
-  }
-
-  /**
-   * @inheritDoc
-   */
-  _decisionChangesNothing(element, decision) {
-    // If the combined settings before and after the decision are the same, then
-    // the decision didn't change anything.
-    // IMPORTANT: The variant decider should return JSON stringified data.
-    const placementId = element.getAttribute('data-ab-tests-instance-id');
-    if (!placementId) {
-      throw new Error(
-        '[A/B Blocks] Unable to find block metadata for a block without a placement ID.',
-      );
-    }
-    const blockMetadata = this.settings?.blocks?.[placementId];
-    if (!blockMetadata) {
-      throw new Error(
-        `[A/B Blocks] Unable to find block metadata for placement ID: ${placementId}`,
-      );
-    }
-    const { blockSettings } = blockMetadata;
-    let parsedDecisionValue = {};
-    try {
-      parsedDecisionValue = JSON.parse(decision.decisionValue);
-    } catch (e) {
-      this.debug &&
-        console.error(
-          `[A/B Blocks] Unable to parse the decision value. Variant deciders should return JSON encoded strings. Received:`,
-          decision.decisionValue,
-        );
-    }
-    const combinedSettings = {
-      ...blockSettings,
-      ...parsedDecisionValue,
-    };
-    // Return true if blockSettings and combinedSettings are the same with a
-    // deep comparison.
-    return this._deepEqual(blockSettings, combinedSettings);
-  }
-
-  /**
-   * Performs a deep comparison of two objects.
-   *
-   * Compares two objects recursively, checking all nested properties and values.
-   * The comparison is order-independent for object keys.
-   *
-   * @param {*} obj1
-   *   The first object to compare.
-   * @param {*} obj2
-   *   The second object to compare.
-   *
-   * @return {boolean}
-   *   True if the objects are deeply equal, false otherwise.
-   *
-   * @private
-   */
-  _deepEqual(obj1, obj2) {
-    // Check strict equality first (handles primitives, null, undefined, same
-    // reference).
-    if (obj1 === obj2) {
-      return true;
-    }
-
-    // Check if either is null or undefined.
-    if (obj1 == null || obj2 == null) {
-      return obj1 === obj2;
-    }
-
-    // Check if types are different.
-    if (typeof obj1 !== typeof obj2) {
-      return false;
-    }
-
-    // Handle arrays.
-    if (Array.isArray(obj1)) {
-      if (!Array.isArray(obj2) || obj1.length !== obj2.length) {
-        return false;
-      }
-      for (let i = 0; i < obj1.length; i++) {
-        if (!this._deepEqual(obj1[i], obj2[i])) {
-          return false;
-        }
-      }
-      return true;
-    }
-
-    // Handle objects.
-    if (typeof obj1 === 'object') {
-      const keys1 = Object.keys(obj1);
-      const keys2 = Object.keys(obj2);
-
-      // Check if they have the same number of keys.
-      if (keys1.length !== keys2.length) {
-        return false;
-      }
-
-      // Check if all keys and values match.
-      return keys1.every(
-        key => keys2.includes(key) && this._deepEqual(obj1[key], obj2[key]),
-      );
-    }
-
-    // For primitives that aren't strictly equal.
-    return false;
   }
 }


### PR DESCRIPTION
If we show the block, and the re-render it for analytics tracking purposes we see a re-render flash.