### PR TITLE
Make Layout Builder a dependency of A/B Blocks

### DIFF
--- a/modules/ab_blocks/ab_blocks.info.yml
+++ b/modules/ab_blocks/ab_blocks.info.yml
@@ -5,4 +5,5 @@ package: A/B Testing
 core_version_requirement: ^10 || ^11
 dependencies:
   - drupal:text
+  - drupal:layout_builder
   - ab_tests:ab_tests


### PR DESCRIPTION
This change will make layout_builder a dependency of the A/B Blocks submodule.

Without this, installing ab_blocks causes a WSOD.

This also resolves issue https://github.com/Lullabot/ab_tests/issues/44, where this bug is described.