### PR TITLE
fix(ab_blocks): tolerate UUID miss across sections in override path

### DIFF
--- a/modules/ab_blocks/src/Controller/AjaxBlockRender.php
+++ b/modules/ab_blocks/src/Controller/AjaxBlockRender.php
@@ -353,7 +353,9 @@ final class AjaxBlockRender extends ControllerBase {
       return NULL;
     }
 
-    // Use array_reduce to find the first component that matches the UUID.
+    // Read from getComponents() — a section that doesn't have the UUID returns
+    // NULL via the array offset, whereas getComponent() throws and aborts the
+    // reducer before later sections are checked.
     $sections = iterator_to_array($layout_field);
     return array_reduce($sections, function (?SectionComponent $carry, $section_list_item) use ($component_uuid) {
       if ($carry !== NULL) {
@@ -361,7 +363,7 @@ final class AjaxBlockRender extends ControllerBase {
       }
       /** @var \Drupal\layout_builder\Section $section */
       $section = $section_list_item->section;
-      return $section->getComponent($component_uuid);
+      return $section->getComponents()[$component_uuid] ?? NULL;
     });
   }
 


### PR DESCRIPTION
## Summary

\`AjaxBlockRender::findComponentInEntityOverride()\` walks every section via \`array_reduce\` and calls \`Section::getComponent(\$uuid)\` for each section. Core's \`Section::getComponent()\` throws \`InvalidArgumentException\` when the UUID isn't present in that particular section — so the first section that doesn't contain the target component aborts the lookup with an uncaught exception, even when the component exists in a later section. The block-render AJAX endpoint then 500s and the user gets a \`Drupal.AjaxError\` dialog.

This PR mirrors the safe \`getComponents()[\$uuid] ?? NULL\` pattern that the same file already uses in \`findComponentInDefaultLayouts()\` (line 418 of the same controller).

## Reproduction

1. Place a block configured for an A/B test in **section ≥ 1** of an entity layout override (e.g. a node's layout override).
2. Load the page anonymously.
3. The \`/ab-blocks/ajax-block/...\` request returns 500. Watchdog logs:

\`\`\`
InvalidArgumentException: Invalid UUID "<uuid>"
  in Drupal\\layout_builder\\Section->getComponent()
#0 …AjaxBlockRender.php(364): …
#1 array_reduce() AjaxBlockRender.php(358)
#2 …findComponentInEntityOverride() AjaxBlockRender.php(328)
#3 …findLayoutBuilderComponent() AjaxBlockRender.php(121)
#4 …AjaxBlockRender->__invoke()
\`\`\`

With this patch the 500 is gone and the configured variant renders.

## Why a tiny diff

\`findComponentInDefaultLayouts()\` already does the right thing 50 lines below. Keeping the change minimal preserves the existing dual-path structure; a follow-up could fold the two helpers into one and add a section-≥1 unit test.

## Test plan

- [ ] Existing tests pass
- [ ] Manual: A/B-tested block placed in **section 0** of an entity override still resolves (no regression)
- [ ] Manual: A/B-tested block placed in **section ≥ 1** of an entity override resolves with HTTP 200 and the variant DOM appears
- [ ] No \`Drupal.AjaxError\` dialog on the page