### PR TITLE
fix(ab_blocks): prefer explicit context_mapping

### DIFF
--- a/modules/ab_blocks/src/Controller/AjaxBlockRender.php
+++ b/modules/ab_blocks/src/Controller/AjaxBlockRender.php
@@ -132,7 +132,13 @@ final class AjaxBlockRender extends ControllerBase {
         ->get('debug_mode');
 
       $current_configuration = $section_component->toArray()['configuration'] ?? [];
-      $section_component->setConfiguration(NestedArray::mergeDeep($current_configuration, $configuration));
+      $merged_configuration = NestedArray::mergeDeep($current_configuration, $configuration);
+      // If the configuration from the URL data has an explicit context mapping,
+      // use that instead of merging.
+      if (array_key_exists('context_mapping', $configuration)) {
+        $merged_configuration['context_mapping'] = $configuration['context_mapping'];
+      }
+      $section_component->setConfiguration($merged_configuration);
       $build = $section_component->toRenderArray($context_values);
     }
     catch (\Exception $e) {


### PR DESCRIPTION
## Summary

- Fixes incorrect block context mappings caused by `NestedArray::mergeDeep` merging context_mapping arrays instead of replacing them.
- When the variant configuration carries an explicit `context_mapping`, it is now used as-is rather than being deep-merged with the original block's context mapping.
- Prevents issues where variant blocks end up with stale or combined context keys from both original and variant configurations.

## Test plan

- [ ] Place a block in Layout Builder with context mappings (e.g., entity context)
- [ ] Configure an A/B variant with a different set of context mappings
- [ ] Verify the variant block renders using only its own context_mapping, not a merge of both
- [ ] Verify blocks without explicit context_mapping in the variant still inherit the original mapping via deep merge